### PR TITLE
Fix bug in retro_branching when done on reset 

### DIFF
--- a/experiments/configs/retro.yaml
+++ b/experiments/configs/retro.yaml
@@ -1,7 +1,10 @@
-defaults:
-  - network: dqn_value_network
-  - agent: dqn_agent
-  - learner: dqn_learner
+network:
+  init_value_network_path:
+  reinitialise_heads: false
+
+agent: {}
+
+
 
 environment:
   observation_function: '43_var_features'
@@ -10,21 +13,17 @@ environment:
   scip_params: 'gasse_2019'
 
 learner:
-  path_to_save: '/scratch/datasets/retro_branching'
+  path_to_save: 'outputs/datasets/retro_branching'
   agent_reward: 'retro_binary_fathomed'
 
 instances:
-  co_class: 'set_covering'
+  co_class: 'capacitated_facility_location'
   co_class_kwargs:
-    'n_rows': 165
-    'n_cols': 230
-  #co_class: 'combinatorial_auction'
-  #co_class_kwargs:
-    #n_items: 10
-    #n_bids: 50
+    'n_customers': 100
+    'n_facilities': 100
 
 experiment:
   seed: 0
-  device: 'cuda:2'
+  device: 'cpu'
   num_epochs: 5000000
   

--- a/retro_branching/src/agents/reinforce_agent.py
+++ b/retro_branching/src/agents/reinforce_agent.py
@@ -118,7 +118,7 @@ class REINFORCEAgent:
         self.filter_mask = np.array([torch.where(self.filter_output >= threshold, 1, 0).detach().cpu().numpy()]).T # column vector
 
         # add filter mask predictions as feature to variable (column) features
-        obs.column_features = np.hstack((obs.column_features, self.filter_mask))
+        obs.variable_features = np.hstack((obs.variable_features, self.filter_mask))
 
         if filter_method == 'method_1':
             # agent can only choose actions permitted by filter_network -> update action_set

--- a/retro_branching/src/learners/dqn_learner.py
+++ b/retro_branching/src/learners/dqn_learner.py
@@ -175,7 +175,7 @@ def extract_state_tensors_from_ecole_obs(obs, action_set):
     return (obs.row_features.astype(np.float32), 
             obs.edge_features.indices.astype(np.int16),
             obs.edge_features.values.astype(np.float32),
-            obs.column_features.astype(np.float32),
+            obs.variable_features.astype(np.float32),
             action_set.astype(np.int16))
 
 def process_episodes_into_subtree_episodes(episode_experiences,
@@ -378,7 +378,7 @@ class BipartiteNodeData(torch_geometric.data.Data):
         # self.constraint_features = torch.FloatTensor(obs.row_features)
         # self.edge_index = torch.LongTensor(obs.edge_features.indices.astype(np.int32))
         # # self.edge_attr = torch.FloatTensor(obs.edge_features.values).unsqueeze(1)
-        # self.variable_features = torch.FloatTensor(obs.column_features)
+        # self.variable_features = torch.FloatTensor(obs.variable_features)
         # self.candidates = torch.from_numpy(candidates.astype(np.int32)).long()
         # self.raw_candidates = torch.from_numpy(candidates.astype(np.int32)).long()
         

--- a/retro_branching/src/networks/bipartite_gcn.py
+++ b/retro_branching/src/networks/bipartite_gcn.py
@@ -350,7 +350,7 @@ class BipartiteGCN(torch.nn.Module):
             # edge_indices = torch.from_numpy(obs.edge_features.indices.astype(np.int16)).to(self.device)
             edge_indices = torch.LongTensor(obs.edge_features.indices.astype(np.int16)).to(self.device)
             edge_features = torch.from_numpy(obs.edge_features.values.astype(np.float32)).view(-1, 1).to(self.device)
-            variable_features = torch.from_numpy(obs.column_features.astype(np.float32)).to(self.device)
+            variable_features = torch.from_numpy(obs.variable_features.astype(np.float32)).to(self.device)
             if self.profile_time:
                 print(f'var feat: {variable_features[0][0]}')
                 t = time.time() - start

--- a/retro_branching/src/networks/bipartite_gcn_no_heads.py
+++ b/retro_branching/src/networks/bipartite_gcn_no_heads.py
@@ -144,7 +144,7 @@ class BipartiteGCNNoHeads(torch.nn.Module):
             constraint_features = torch.from_numpy(obs.row_features.astype(np.float32)).to(self.device)
             edge_indices = torch.from_numpy(obs.edge_features.indices.astype(np.int64)).to(self.device)
             edge_features = torch.from_numpy(obs.edge_features.values.astype(np.float32)).view(-1, 1).to(self.device)
-            variable_features = torch.from_numpy(obs.column_features.astype(np.float32)).to(self.device)
+            variable_features = torch.from_numpy(obs.variable_features.astype(np.float32)).to(self.device)
 
         reversed_edge_indices = torch.stack([edge_indices[1], edge_indices[0]], dim=0)
         

--- a/retro_branching/src/observations/node_bipartite_with_24_variable_features.py
+++ b/retro_branching/src/observations/node_bipartite_with_24_variable_features.py
@@ -49,8 +49,8 @@ class NodeBipariteWith24VariableFeatures(ecole.observation.NodeBipartite):
                                  max_primal_bound_frac_change,
                                  max_dual_bound_frac_change,
                                  curr_primal_dual_bound_gap_frac,
-                                 ] for _ in range(obs.column_features.shape[0])])
+                                 ] for _ in range(obs.variable_features.shape[0])])
         
-        obs.column_features = np.column_stack((obs.column_features, feats_to_add))
+        obs.variable_features = np.column_stack((obs.variable_features, feats_to_add))
                 
         return obs

--- a/retro_branching/src/observations/node_bipartite_with_28_variable_features.py
+++ b/retro_branching/src/observations/node_bipartite_with_28_variable_features.py
@@ -58,8 +58,8 @@ class NodeBipariteWith28VariableFeatures(ecole.observation.NodeBipartite):
                                  num_infeasible_leaves_frac,
                                  num_lp_iterations_frac,
                                  num_children_frac,
-                                 num_siblings_frac] for _ in range(obs.column_features.shape[0])])
+                                 num_siblings_frac] for _ in range(obs.variable_features.shape[0])])
         
-        obs.column_features = np.column_stack((obs.column_features, feats_to_add))
+        obs.variable_features = np.column_stack((obs.variable_features, feats_to_add))
                 
         return obs

--- a/retro_branching/src/observations/node_bipartite_with_29_variable_features.py
+++ b/retro_branching/src/observations/node_bipartite_with_29_variable_features.py
@@ -129,7 +129,7 @@ class NodeBipariteWith29VariableFeatures(ecole.observation.NodeBipartite):
                                  is_best_sibling_none,
                                  is_best_sibling_best_node,
                                  best_sibling_lower_bound_relative_to_init_dual_bound,
-                                 best_sibling_lower_bound_relative_to_curr_node_lower_bound] for _ in range(obs.column_features.shape[0])])
+                                 best_sibling_lower_bound_relative_to_curr_node_lower_bound] for _ in range(obs.variable_features.shape[0])])
 
         # # TEMP DEBUGGING
         # illegal_feat_idx_to_val = defaultdict(lambda: [])
@@ -142,7 +142,7 @@ class NodeBipariteWith29VariableFeatures(ecole.observation.NodeBipartite):
         # if illegal_found:
             # raise Exception(f'Found illegal feature(s): {illegal_feat_idx_to_val}')
         
-        obs.column_features = np.column_stack((obs.column_features, feats_to_add))
+        obs.variable_features = np.column_stack((obs.variable_features, feats_to_add))
 
                 
         return obs

--- a/retro_branching/src/observations/node_bipartite_with_37_variable_features.py
+++ b/retro_branching/src/observations/node_bipartite_with_37_variable_features.py
@@ -131,7 +131,7 @@ class NodeBipariteWith37VariableFeatures(ecole.observation.NodeBipartite):
                                  best_sibling_lower_bound_relative_to_init_dual_bound,
                                  best_sibling_lower_bound_relative_to_curr_node_lower_bound
                                  ] 
-                                 for _ in range(obs.column_features.shape[0])])
+                                 for _ in range(obs.variable_features.shape[0])])
 
         # # TEMP DEBUGGING
         # illegal_feat_idx_to_val = defaultdict(lambda: [])
@@ -144,7 +144,7 @@ class NodeBipariteWith37VariableFeatures(ecole.observation.NodeBipartite):
         # if illegal_found:
             # raise Exception(f'Found illegal feature(s): {illegal_feat_idx_to_val}')
         
-        obs.column_features = np.column_stack((obs.column_features, feats_to_add))
+        obs.variable_features = np.column_stack((obs.variable_features, feats_to_add))
 
                 
         return obs

--- a/retro_branching/src/observations/node_bipartite_with_40_variable_features.py
+++ b/retro_branching/src/observations/node_bipartite_with_40_variable_features.py
@@ -126,8 +126,8 @@ class NodeBipariteWith40VariableFeatures(ecole.observation.NodeBipartite):
                                  is_best_sibling_best_node,
                                  best_sibling_lower_bound_relative_to_init_dual_bound,
                                  best_sibling_lower_bound_relative_to_curr_dual_bound,
-                                 best_sibling_lower_bound_relative_to_curr_node_lower_bound] for _ in range(obs.column_features.shape[0])])
+                                 best_sibling_lower_bound_relative_to_curr_node_lower_bound] for _ in range(obs.variable_features.shape[0])])
         
-        obs.column_features = np.column_stack((obs.column_features, feats_to_add))
+        obs.variable_features = np.column_stack((obs.variable_features, feats_to_add))
                 
         return obs

--- a/retro_branching/src/observations/node_bipartite_with_43_variable_features.py
+++ b/retro_branching/src/observations/node_bipartite_with_43_variable_features.py
@@ -115,6 +115,11 @@ class NodeBipariteWith43VariableFeatures(ecole.observation.NodeBipartite):
             best_sibling_lower_bound_relative_to_init_dual_bound = 0
             best_sibling_lower_bound_relative_to_curr_dual_bound = 0
             best_sibling_lower_bound_relative_to_curr_node_lower_bound = 0
+
+        #print(dir(obs))
+        #print(obs.edge_features)
+        #print(obs.row_features)
+        #print(obs.variable_features)
         
         # add feats to each variable
         feats_to_add = np.array([[dual_bound_frac_change,
@@ -140,7 +145,7 @@ class NodeBipariteWith43VariableFeatures(ecole.observation.NodeBipartite):
                                  is_best_sibling_best_node,
                                  best_sibling_lower_bound_relative_to_init_dual_bound,
                                  best_sibling_lower_bound_relative_to_curr_dual_bound,
-                                 best_sibling_lower_bound_relative_to_curr_node_lower_bound] for _ in range(obs.column_features.shape[0])])
+                                 best_sibling_lower_bound_relative_to_curr_node_lower_bound] for _ in range(obs.variable_features.shape[0])])
 
         # # TEMP DEBUGGING
         # illegal_feat_idx_to_val = defaultdict(lambda: [])
@@ -153,7 +158,7 @@ class NodeBipariteWith43VariableFeatures(ecole.observation.NodeBipartite):
         # if illegal_found:
             # raise Exception(f'Found illegal feature(s): {illegal_feat_idx_to_val}')
         
-        obs.column_features = np.column_stack((obs.column_features, feats_to_add))
+        obs.variable_features = np.column_stack((obs.variable_features, feats_to_add))
 
                 
         return obs

--- a/retro_branching/src/observations/node_bipartite_with_43_variable_features.py
+++ b/retro_branching/src/observations/node_bipartite_with_43_variable_features.py
@@ -13,23 +13,23 @@ class NodeBipariteWith43VariableFeatures(ecole.observation.NodeBipartite):
     '''
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        
+
     def before_reset(self, model):
         super().before_reset(model)
-        
+
         self.init_dual_bound = None
         self.init_primal_bound = None
-        
+
     def extract(self, model, done):
         # get the NodeBipartite obs
         obs = super().extract(model, done)
-        
+
         m = model.as_pyscipopt()
-        
+
         if self.init_dual_bound is None:
             self.init_dual_bound = m.getDualbound()
             self.init_primal_bound = m.getPrimalbound()
-            
+
         # dual/primal bound features
         # dual_bound_frac_change = abs(1-(min(self.init_dual_bound, m.getDualbound()) / max(self.init_dual_bound, m.getDualbound())))
         # primal_bound_frac_change = abs(1-(min(self.init_primal_bound, m.getPrimalbound()) / max(self.init_primal_bound, m.getPrimalbound())))
@@ -41,7 +41,7 @@ class NodeBipariteWith43VariableFeatures(ecole.observation.NodeBipartite):
         max_primal_bound_frac_change = primal_dual_gap / self.init_primal_bound
 
         curr_primal_dual_bound_gap_frac = m.getGap()
-        
+
         # global tree features
         num_leaves_frac = m.getNLeaves() / m.getNNodes()
         num_feasible_leaves_frac = m.getNFeasibleLeaves() / m.getNNodes()
@@ -50,7 +50,7 @@ class NodeBipariteWith43VariableFeatures(ecole.observation.NodeBipartite):
 #         num_feasible_sols_found_frac = m.getNSolsFound() / m.getNNodes() # gives idea for how hard problem is, since harder problems may have more sparse feasible solutions?
 #         num_feasible_best_sols_found_frac = m.getNBestSolsFound() / m.getNSolsFound()
         num_lp_iterations_frac = m.getNNodes() / m.getNLPIterations()
-        
+
         # focus node features
         num_siblings_frac = m.getNSiblings() / m.getNNodes()
         curr_node = m.getCurrentNode()
@@ -116,11 +116,6 @@ class NodeBipariteWith43VariableFeatures(ecole.observation.NodeBipartite):
             best_sibling_lower_bound_relative_to_curr_dual_bound = 0
             best_sibling_lower_bound_relative_to_curr_node_lower_bound = 0
 
-        #print(dir(obs))
-        #print(obs.edge_features)
-        #print(obs.row_features)
-        #print(obs.variable_features)
-        
         # add feats to each variable
         feats_to_add = np.array([[dual_bound_frac_change,
                                  primal_bound_frac_change,
@@ -151,14 +146,14 @@ class NodeBipariteWith43VariableFeatures(ecole.observation.NodeBipartite):
         # illegal_feat_idx_to_val = defaultdict(lambda: [])
         # illegal_found = False
         # for var in feats_to_add:
-            # for idx, feat in enumerate(var): 
+            # for idx, feat in enumerate(var):
                 # if feat < -1 or feat > 1:
                     # illegal_found = True
                     # illegal_feat_idx_to_val[idx].append(feat)
         # if illegal_found:
             # raise Exception(f'Found illegal feature(s): {illegal_feat_idx_to_val}')
-        
+
         obs.variable_features = np.column_stack((obs.variable_features, feats_to_add))
 
-                
+
         return obs

--- a/retro_branching/src/observations/node_bipartite_with_45_variable_features.py
+++ b/retro_branching/src/observations/node_bipartite_with_45_variable_features.py
@@ -135,8 +135,8 @@ class NodeBipariteWith45VariableFeatures(ecole.observation.NodeBipartite):
                                  is_best_sibling_best_node,
                                  best_sibling_lower_bound_relative_to_init_dual_bound,
                                  best_sibling_lower_bound_relative_to_curr_dual_bound,
-                                 best_sibling_lower_bound_relative_to_curr_node_lower_bound] for _ in range(obs.column_features.shape[0])])
+                                 best_sibling_lower_bound_relative_to_curr_node_lower_bound] for _ in range(obs.variable_features.shape[0])])
         
-        obs.column_features = np.column_stack((obs.column_features, feats_to_add))
+        obs.variable_features = np.column_stack((obs.variable_features, feats_to_add))
                 
         return obs

--- a/retro_branching/src/observations/node_bipartite_with_custom_features.py
+++ b/retro_branching/src/observations/node_bipartite_with_custom_features.py
@@ -40,11 +40,11 @@ class NodeBipariteWithCustomFeatures(ecole.observation.NodeBipartite):
             self.obj_coeffs_renorm = self.obj_coeffs_norm / np.sum(var_coeffs)
 
         # print("row_features", obs.row_features.shape) # [500,5]
-        # print("col_features", obs.column_features.shape) # [1000,19]
+        # print("col_features", obs.variable_features.shape) # [1000,19]
         # print("edge_features", obs.edge_features.shape) # [500,1000]
 
         # remove scaled age
-        # obs.column_features = np.delete(obs.column_features, 12, -1)
+        # obs.variable_features = np.delete(obs.variable_features, 12, -1)
 
         # Global primal/dual.
         glob_primal_bound, glob_dual_bound = m.getPrimalbound(), m.getDualbound()
@@ -73,13 +73,13 @@ class NodeBipariteWithCustomFeatures(ecole.observation.NodeBipartite):
             primal_change_gap,
             curr_node_depth,
         ])
-        features_to_add = features_to_add[None].repeat(obs.column_features.shape[0], 0)
+        features_to_add = features_to_add[None].repeat(obs.variable_features.shape[0], 0)
 
-        # obs.column_features[..., 0] = obs.column_features[..., 0] * self.obj_coeffs_renorm
-        # obs.column_features[..., 7] = obs.column_features[..., 7] * self.obj_coeffs_renorm
+        # obs.variable_features[..., 0] = obs.variable_features[..., 0] * self.obj_coeffs_renorm
+        # obs.variable_features[..., 7] = obs.variable_features[..., 7] * self.obj_coeffs_renorm
 
-        obs.column_features = np.column_stack([
-            obs.column_features,
+        obs.variable_features = np.column_stack([
+            obs.variable_features,
             features_to_add,
         ])
 

--- a/retro_branching/src/observations/node_bipartite_with_solution_labels.py
+++ b/retro_branching/src/observations/node_bipartite_with_solution_labels.py
@@ -30,6 +30,6 @@ class NodeBipariteWithSolutionLabels(ecole.observation.NodeBipartite):
         obs = super().extract(model, done)
 
         # label vars in obs with final solution values
-        obs.column_features = np.column_stack((obs.column_features, self.presolve_sol_vals))
+        obs.variable_features = np.column_stack((obs.variable_features, self.presolve_sol_vals))
 
         return obs

--- a/retro_branching/src/rewards/normalised_lp_gain.py
+++ b/retro_branching/src/rewards/normalised_lp_gain.py
@@ -49,7 +49,7 @@ class NormalisedLPGain:
                 self.prev_node_id = copy.deepcopy(self.prev_node.getNumber())
                 self.prev_primal_bound = m.getPrimalbound()
                 self.init_primal_bound = m.getPrimalbound()
-            return 0
+            # return 0  # dsorokin: I think it is bug
 
         # update search tree with current model state
         self.tree.update_tree(model)

--- a/retro_branching/src/rewards/normalised_lp_gain.py
+++ b/retro_branching/src/rewards/normalised_lp_gain.py
@@ -49,7 +49,6 @@ class NormalisedLPGain:
                 self.prev_node_id = copy.deepcopy(self.prev_node.getNumber())
                 self.prev_primal_bound = m.getPrimalbound()
                 self.init_primal_bound = m.getPrimalbound()
-            # return 0  # dsorokin: I think it is bug
 
         # update search tree with current model state
         self.tree.update_tree(model)

--- a/retro_branching/utils.py
+++ b/retro_branching/utils.py
@@ -420,11 +420,11 @@ class GraphDataset(torch_geometric.data.Dataset):
         candidate_choice = torch.where(candidates == sample_action)[0][0]
 
         graph = BipartiteNodeData(sample_observation.row_features, sample_observation.edge_features.indices, 
-                                  sample_observation.edge_features.values, sample_observation.column_features,
+                                  sample_observation.edge_features.values, sample_observation.variable_features,
                                   candidates, candidate_choice, candidate_scores, score)
         
         # We must tell pytorch geometric how many nodes there are, for indexing purposes
-        graph.num_nodes = sample_observation.row_features.shape[0]+sample_observation.column_features.shape[0]
+        graph.num_nodes = sample_observation.row_features.shape[0]+sample_observation.variable_features.shape[0]
         
         return graph
 

--- a/retro_branching/validators.py
+++ b/retro_branching/validators.py
@@ -137,12 +137,12 @@ def calibrate_hardware(calibration_config, device, kwargs):
 # def extract_state_tensors_from_ecole_obs(obs, device):
     # return (torch.from_numpy(obs.row_features.astype(np.float32)).to(device), 
             # torch.LongTensor(obs.edge_features.indices.astype(np.int16)).to(device),
-            # torch.from_numpy(obs.column_features.astype(np.float32)).to(device))
+            # torch.from_numpy(obs.variable_features.astype(np.float32)).to(device))
 def extract_state_tensors_from_ecole_obs(obs, device):
     return (torch.from_numpy(obs.row_features.astype(np.float32)).to(device), 
             torch.LongTensor(obs.edge_features.indices.astype(np.int16)).to(device),
             torch.from_numpy(obs.edge_features.values.astype(np.float32)).to(device).unsqueeze(1),
-            torch.from_numpy(obs.column_features.astype(np.float32)).to(device))
+            torch.from_numpy(obs.variable_features.astype(np.float32)).to(device))
 
 
 


### PR DESCRIPTION
* When [retro_branching::extract](https://github.com/cwfparsonson/retro_branching/blob/master/retro_branching/src/rewards/retro_branching.py#L263) is called first time it creates a tree [without scores](https://github.com/cwfparsonson/retro_branching/blob/master/retro_branching/src/rewards/normalised_lp_gain.py#L52). If env is done on reset it will remove [all nodes](https://github.com/cwfparsonson/retro_branching/blob/master/retro_branching/src/rewards/retro_branching.py#L293) and will rise a error when [accessing removed root node](https://github.com/cwfparsonson/retro_branching/blob/master/retro_branching/src/rewards/retro_branching.py#L379). My solution is to set scores when creating the tree. 
* rename column_features -> variable_features to support the latest ecole/scip version 
* modify config for retro so it will run 